### PR TITLE
Updated Application To Rename vs Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ You need a Vita running HENkaku to be able to use CardUnlock. Install the vpk in
 ## How to use it
 
 * start Vita without the card inserted
-* run HENkaku and  start CardUnlock
-* insert card, answer "no" to "do you want to reboot now" message
-* press X to remove id.dat
+* run HENkaku and start CardUnlock
+* insert the memory card, answer "no" to the "do you want to reboot now" message from the system
+* press X to rename id.dat
 * press X to reboot or O to exit (after pressing O you can remove the card to insert in another device)
-* answer "no" to questions about copying content to the card
+* answer "no" to questions about copying content to the card from the system
 * you now have access to the card
 
 ## How does it work?
 
-The Vita looks at the file id.dat in the root of the card to see if it's attached to another user/version when mounting the card. Removing this file makes the Vita think this is a new card allowing you to mount it. The problem is that you need to mount the card to remove the file and mounting ux0: causes the Vita to check the file before you can delete it. CardUnlock gets around this by mounting the card as xmc0: which is the actual mount point for external cards. The Vita doesn't check for id.dat when you mount xmc0: so we can mount the device and delete id.dat.
+The Vita looks at the file id.dat in the root of the card to see if it's attached to another user/version when mounting the card. Removing/renaming this file makes the Vita think this is a new card allowing you to mount it. The problem is that you need to mount the card to access the file and mounting ux0: causes the Vita to check the file before you can delete it. CardUnlock gets around this by mounting the card as xmc0: which is the actual mount point for external cards. The Vita doesn't check for id.dat when you mount xmc0: so we can mount the device and rename id.dat.
 
 ## Credits
 

--- a/main.c
+++ b/main.c
@@ -34,14 +34,22 @@ int main(int argc, char *argv[])
 	psvDebugScreenInit();
 
 	psvDebugScreenSetFgColor(COLOR_WHITE);
-	printf("CardUnlock by cnsldv\n");
-	printf("====================\n");
+	printf("CardUnlock v1.1 by cnsldv (Contributions By Hexxellor)\n");
+	printf("======================================================\n");
+	printf("NOTE: This application will attempt to rename the\n");
+	printf("id.dat file on your memory card to id.bak. This will\n");
+	printf("allow you to preserve the original in case you want to\n");
+	printf("retrieve any information from it.\n");
+	printf("======================================================\n");
 	printf("\n");
 	psvDebugScreenSetFgColor(COLOR_RED);
-	printf("WARNING: use of this program is at your own risk!\n");
+	printf("WARNING: Use of this program is at your own risk!\n");
+	printf("         If a backup file (id.bak) exists already\n");
+	printf("         it will be removed so backup the file\n");
+	printf("         if you need to keep it!\n");
 	psvDebugScreenSetFgColor(COLOR_WHITE);
 	printf("\n");
-	
+
 	printf("Insert card now, select \"No\" when asked to reboot\n");
 
 	printf("Once card is inserted press X to continue\n");
@@ -58,15 +66,32 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	printf("Removing id.dat\n");
+	// Remove the old id.bak file if it exists
+	printf("Checking for existing id.bak file...\n");
+	fd = sceIoOpen("xmc0:id.bak", SCE_O_RDONLY, 0);
+	if (fd >= 0) {
+		sceIoClose(fd);
+		printf("Removing old id.bak file\n");
+		ret = sceIoRemove("xmc0:id.bak");
+		if (ret != 0) {
+			psvDebugScreenSetFgColor(COLOR_RED);
+			psvDebugScreenPrintf("Unable to remove id.bak err=0x%08X\n", ret);
+			psvDebugScreenSetFgColor(COLOR_WHITE);
+		}
+	}
+
+	// Rename the id.dat file to id.bak so we can retain the information in it.
+	// NOTE: Technically if the previous attempt to remove an existing id.bak fails
+	//       proceeding with this is sort of stupid. *shrug* Lots of checking could be
+	//       added. Don't care. :)
+	printf("Renaming current id.dat to id.bak\n");
 	fd = sceIoOpen("xmc0:id.dat", SCE_O_RDONLY, 0);
 	if (fd >= 0) {
 		sceIoClose(fd);
-	
-		ret = sceIoRemove("xmc0:id.dat");
+		ret = sceIoRename("xmc0:id.dat", "xmc0:id.bak");
 		if (ret != 0) {
 			psvDebugScreenSetFgColor(COLOR_RED);
-			psvDebugScreenPrintf("Unable to remove id.dat err=0x%08X\n", ret);
+			psvDebugScreenPrintf("Unable to rename id.dat err=0x%08X\n", ret);
 			psvDebugScreenSetFgColor(COLOR_WHITE);
 		}
 	}
@@ -113,4 +138,3 @@ unsigned int wait_keys(unsigned int key_mask)
 		sceKernelDelayThreadCB(200 * 1000);
 	}
 }
-


### PR DESCRIPTION
Changed the program so it will rename the id.dat file instead of deleting it. This allows you to retrieve the file later and get data out of it in case you want to see the info about the account previously associated with the card (This isn't everything about the account, of course).